### PR TITLE
Fix GPIO for libgpiod v2

### DIFF
--- a/include/GPIO/gpio-line.hpp
+++ b/include/GPIO/gpio-line.hpp
@@ -14,6 +14,6 @@ public:
   void off() { set(false); }
 
 private:
-  gpiod_chip* chip_ = nullptr;
-  gpiod_line* line_ = nullptr;
+  gpiod_line_request* req_ = nullptr;
+  unsigned int offset_ = 0;
 };

--- a/src/LED/led-gpio-line.cpp
+++ b/src/LED/led-gpio-line.cpp
@@ -1,41 +1,88 @@
 #include "GPIO/gpio-line.hpp"
+
+#include <cerrno>
+#include <cstring>
 #include <stdexcept>
+#include <string>
 
-GpioLine::GpioLine(const char* chip_name, int line_offset, const char* consumer) {
-  chip_ = gpiod_chip_open_by_name(chip_name);
-  if (!chip_) {
-    throw std::runtime_error("gpiod_chip_open_by_name failed");
+static std::string chip_path_from_name(const char* chip_name) {
+  if (!chip_name) return "/dev/gpiochip0";
+  std::string s(chip_name);
+  if (s.rfind("/dev/", 0) == 0) return s;       // already path
+  return std::string("/dev/") + s;              // "gpiochip0" -> "/dev/gpiochip0"
+}
+
+static gpiod_line_request* request_output_line(const char* chip_name,
+                                               unsigned int offset,
+                                               const char* consumer,
+                                               enum gpiod_line_value initial) {
+  const std::string chip_path = chip_path_from_name(chip_name);
+
+  gpiod_chip* chip = gpiod_chip_open(chip_path.c_str());
+  if (!chip) return nullptr;
+
+  gpiod_line_settings* settings = gpiod_line_settings_new();
+  if (!settings) { gpiod_chip_close(chip); return nullptr; }
+  gpiod_line_settings_set_direction(settings, GPIOD_LINE_DIRECTION_OUTPUT);
+
+  gpiod_line_config* line_cfg = gpiod_line_config_new();
+  if (!line_cfg) {
+    gpiod_line_settings_free(settings);
+    gpiod_chip_close(chip);
+    return nullptr;
   }
 
-  line_ = gpiod_chip_get_line(chip_, line_offset);
-  if (!line_) {
-    gpiod_chip_close(chip_);
-    chip_ = nullptr;
-    throw std::runtime_error("gpiod_chip_get_line failed");
+  int ret = gpiod_line_config_add_line_settings(line_cfg, &offset, 1, settings);
+  if (ret) {
+    gpiod_line_config_free(line_cfg);
+    gpiod_line_settings_free(settings);
+    gpiod_chip_close(chip);
+    return nullptr;
   }
 
-  // 申请输出模式，初始值 0（灯灭）
-  if (gpiod_line_request_output(line_, consumer, 0) < 0) {
-    gpiod_chip_close(chip_);
-    chip_ = nullptr;
-    line_ = nullptr;
-    throw std::runtime_error("gpiod_line_request_output failed (permission or busy?)");
+  // initial output value
+  ret = gpiod_line_config_set_output_values(line_cfg, &initial, 1);
+  if (ret) {
+    gpiod_line_config_free(line_cfg);
+    gpiod_line_settings_free(settings);
+    gpiod_chip_close(chip);
+    return nullptr;
+  }
+
+  gpiod_request_config* req_cfg = gpiod_request_config_new();
+  if (req_cfg && consumer) gpiod_request_config_set_consumer(req_cfg, consumer);
+
+  gpiod_line_request* request = gpiod_chip_request_lines(chip, req_cfg, line_cfg);
+
+  gpiod_request_config_free(req_cfg);
+  gpiod_line_config_free(line_cfg);
+  gpiod_line_settings_free(settings);
+  gpiod_chip_close(chip);
+
+  return request;
+}
+
+GpioLine::GpioLine(const char* chip_name, int line_offset, const char* consumer)
+  : offset_(static_cast<unsigned int>(line_offset)) {
+  req_ = request_output_line(chip_name, offset_, consumer ? consumer : "door-access", GPIOD_LINE_VALUE_INACTIVE);
+  if (!req_) {
+    throw std::runtime_error(std::string("Failed to request GPIO line: ") + std::strerror(errno));
   }
 }
 
 GpioLine::~GpioLine() {
-  if (line_) {
-    gpiod_line_set_value(line_, 0);
-    gpiod_line_release(line_);
-    line_ = nullptr;
-  }
-  if (chip_) {
-    gpiod_chip_close(chip_);
-    chip_ = nullptr;
+  if (req_) {
+    // best-effort: set low then release
+    gpiod_line_request_set_value(req_, offset_, GPIOD_LINE_VALUE_INACTIVE);
+    gpiod_line_request_release(req_);
+    req_ = nullptr;
   }
 }
 
 void GpioLine::set(bool high) {
-  if (!line_) return;
-  gpiod_line_set_value(line_, high ? 1 : 0);
+  if (!req_) return;
+  gpiod_line_request_set_value(
+      req_, offset_,
+      high ? GPIOD_LINE_VALUE_ACTIVE : GPIOD_LINE_VALUE_INACTIVE
+  );
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,4 @@
-#include "led/led-v1.hpp"
+#include "LED/led-v1.hpp"
 #include "GPIO/gpio-line.hpp"
 #include <chrono>
 #include <thread>


### PR DESCRIPTION
The GPIO API has been upgraded from v1.6.3 to v2.2.1 (the version used on Raspberry Pi 5). 
Fixed an issue where it failed to compile on Raspberry Pi.